### PR TITLE
feat: Day 07 hardening baseline for defaults + examples

### DIFF
--- a/.github/workflows/module-test-harness.yml
+++ b/.github/workflows/module-test-harness.yml
@@ -1,0 +1,21 @@
+name: Module Test Harness
+
+on:
+  pull_request:
+    branches: [master]
+
+permissions:
+  contents: read
+
+jobs:
+  basic-example:
+    uses: clouddrove/github-shared-workflows/.github/workflows/stf-checks.yml@bd958ead76ac7c72acf4976c244c47eef89c84f7
+    with:
+      provider: digitalocean
+      working_directory: ./_examples/basic/
+
+  complete-example:
+    uses: clouddrove/github-shared-workflows/.github/workflows/stf-checks.yml@bd958ead76ac7c72acf4976c244c47eef89c84f7
+    with:
+      provider: digitalocean
+      working_directory: ./_examples/complete/

--- a/variables.tf
+++ b/variables.tf
@@ -17,6 +17,11 @@ variable "ttl" {
   type        = number
   default     = 3600
   description = "The time to live for the CDN Endpoint, in seconds. Default is 3600 seconds."
+
+  validation {
+    condition     = var.ttl >= 60 && var.ttl <= 604800
+    error_message = "ttl must be between 60 and 604800 seconds."
+  }
 }
 
 variable "certificate_name" {


### PR DESCRIPTION
## Summary
- Added reusable `module-test-harness` workflow using only `clouddrove/github-shared-workflows`.
- Hardened input defaults by enforcing safe TTL bounds (60..604800 seconds).

## Ticket Mapping
- Project #2 Day 07: Harden `terraform-digitalocean-cdn` defaults + examples.

## Validation
- CI will run PR validation, tf-checks, checkov, and the new module test harness workflow.

## Checklist
- [x] Clean markdown body (no escaped newlines)
- [x] Reusable workflows sourced only from `clouddrove/github-shared-workflows`
- [x] No merge performed