### PR TITLE
chore: standardize repo with security policy, pre-commit, and release automation

### DIFF
--- a/.github/workflows/pr_checks.yml
+++ b/.github/workflows/pr_checks.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   pr-validation:
     if: github.actor != 'dependabot[bot]'
-    uses: clouddrove/github-shared-workflows/.github/workflows/pr_checks.yml@a26d1abb482f8615f50f54e3e5ca2b9ed0e349d4 # pinned to latest
+    uses: clouddrove/github-shared-workflows/.github/workflows/pr-checks.yml@a26d1abb482f8615f50f54e3e5ca2b9ed0e349d4 # pinned to latest
     secrets: inherit
     with:
       subjectPattern: '^.+$'

--- a/.github/workflows/tf-checks.yml
+++ b/.github/workflows/tf-checks.yml
@@ -8,13 +8,15 @@ jobs:
   basic-example:
     uses: clouddrove/github-shared-workflows/.github/workflows/stf-checks.yml@521761c1a5cf68d919980a2ed84b755182aeabfe # pinned to latest
     with:
-      provider: digitalocean
+      provider: none
       working_directory: './_examples/basic/'
+      provider: none
   complete-example:
     uses: clouddrove/github-shared-workflows/.github/workflows/stf-checks.yml@521761c1a5cf68d919980a2ed84b755182aeabfe # pinned to latest
     with:
-      provider: digitalocean
+      provider: none
       working_directory: './_examples/complete/'
+      provider: none
 
 # Separate job for TFlint workflow call
   tf-lint:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,21 +1,29 @@
 repos:
-
-  - repo: https://github.com/gruntwork-io/pre-commit
-    rev: v0.1.23 # Get the latest from: https://github.com/gruntwork-io/pre-commit/releases
+  - repo: https://github.com/antonbabenko/pre-commit-terraform
+    rev: v1.105.0
     hooks:
-      - id: terraform-fmt
-      - id: shellcheck
-      - id: tflint
-
+      - id: terraform_fmt
+      - id: terraform_docs
+        args:
+          - '--args=--lockfile=false'
+      - id: terraform_tflint
+        args:
+          - '--args=--only=terraform_deprecated_interpolation'
+          - '--args=--only=terraform_deprecated_index'
+          - '--args=--only=terraform_unused_declarations'
+          - '--args=--only=terraform_comment_syntax'
+          - '--args=--only=terraform_documented_outputs'
+          - '--args=--only=terraform_documented_variables'
+          - '--args=--only=terraform_typed_variables'
+          - '--args=--only=terraform_module_pinned_source'
+          - '--args=--only=terraform_naming_convention'
+          - '--args=--only=terraform_required_version'
+          - '--args=--only=terraform_required_providers'
+          - '--args=--only=terraform_standard_module_structure'
+      - id: terraform_validate
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0 # Use the ref you want to point at
+    rev: v5.0.0
     hooks:
+      - id: check-merge-conflict
       - id: end-of-file-fixer
       - id: trailing-whitespace
-      - id: mixed-line-ending
-      - id: check-byte-order-marker
-      - id: check-executables-have-shebangs
-      - id: check-merge-conflict
-      - id: debug-statements
-      - id: check-yaml
-      - id: check-added-large-files

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,0 +1,14 @@
+{
+  "branches": ["main", "master"],
+  "ci": false,
+  "plugins": [
+    ["@semantic-release/commit-analyzer", {"preset": "conventionalcommits"}],
+    ["@semantic-release/release-notes-generator", {"preset": "conventionalcommits"}],
+    ["@semantic-release/github", {
+      "successComment": "This ${issue.pull_request ? 'PR is included' : 'issue has been resolved'} in version ${nextRelease.version}",
+      "labels": false
+    }],
+    ["@semantic-release/changelog", {"changelogFile": "CHANGELOG.md"}],
+    ["@semantic-release/git", {"assets": ["CHANGELOG.md"], "message": "chore(release): version ${nextRelease.version} [skip ci]"}]
+  ]
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,104 @@
+# Contributing
+
+We welcome contributions! This document provides guidelines for contributing to this project.
+
+## Code of Conduct
+
+Please be respectful and constructive. We are committed to providing a welcoming and inclusive experience for everyone.
+
+## Getting Started
+
+1. Fork the repository
+2. Clone your fork locally
+3. Create a feature branch from `master`
+4. Make your changes
+5. Test your changes
+6. Submit a pull request
+
+## Development Setup
+
+### Prerequisites
+
+- [Terraform](https://www.terraform.io/downloads.html) >= 1.10.0
+- [pre-commit](https://pre-commit.com/#install)
+- [TFLint](https://github.com/terraform-linters/tflint)
+- [terraform-docs](https://terraform-docs.io/)
+
+### Local Development
+
+```bash
+# Install pre-commit hooks
+pre-commit install
+
+# Run all pre-commit checks
+pre-commit run -a
+
+# Format code
+terraform fmt -recursive
+
+# Validate module
+terraform init -backend=false
+terraform validate
+```
+
+## Pull Request Process
+
+### Commit Messages
+
+We use [Conventional Commits](https://www.conventionalcommits.org/). All commit messages and PR titles must follow this format:
+
+```
+type: description
+```
+
+**Allowed types:** `fix`, `feat`, `docs`, `ci`, `chore`, `test`, `refactor`, `style`, `perf`, `build`, `revert`
+
+**Examples:**
+- `feat: add support for custom tags`
+- `fix: correct subnet CIDR calculation`
+- `docs: update usage examples`
+- `ci: pin workflow actions to SHA`
+
+### PR Checklist
+
+- [ ] Code follows the existing style and conventions
+- [ ] Updated or added examples in `examples/` directory
+- [ ] Ran `pre-commit run -a` locally
+- [ ] Updated documentation if needed
+- [ ] All CI checks pass
+
+### What to Include
+
+- Clear description of what changed and why
+- Link to any related issues
+- Example usage if adding new features
+- Test evidence (terraform validate output, plan output)
+
+## Module Structure
+
+```
+module/
+├── main.tf           # Primary resources
+├── variables.tf      # Input variables
+├── outputs.tf        # Output values
+├── versions.tf       # Provider and Terraform version constraints
+├── locals.tf         # Local values (if needed)
+├── data.tf           # Data sources (if needed)
+├── examples/         # Usage examples
+│   ├── basic/        # Minimal working example
+│   └── complete/     # Full-featured example
+├── README.md         # Documentation (auto-generated)
+├── README.yaml       # Documentation source
+└── CHANGELOG.md      # Version history
+```
+
+## Versioning
+
+We follow [Semantic Versioning](https://semver.org/):
+- **MAJOR**: Breaking changes
+- **MINOR**: New features (backwards compatible)
+- **PATCH**: Bug fixes (backwards compatible)
+
+## Questions?
+
+Open an issue or reach out at **support@clouddrove.com**.


### PR DESCRIPTION
## Summary
- Add SECURITY.md with vulnerability reporting policy
- Add CONTRIBUTING.md with development guidelines
- Add .releaserc.json for semantic-release automation
- Update .editorconfig to match industry standards
- Update .pre-commit-config.yaml to antonbabenko/pre-commit-terraform v1.105.0
- Set provider: none in tf-checks workflow (skip cloud auth for validate-only)
- Fix version constraints if needed

## Test plan
- [ ] Verify pre-commit hooks pass locally
- [ ] Verify CI checks pass
- [ ] Verify terraform validate succeeds